### PR TITLE
feat: add /abbie-axel redirect for wedding info page

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -9,6 +9,7 @@
 / https://ofreport.com/ 301
 
 # Trailing slash redirects (handle URLs with trailing slashes)
+/abbie-axel/ /abbie-axel 301
 /wish-list/ /wish-list 301
 /fb/ /fb 301
 /x/ /x 301
@@ -26,6 +27,7 @@
 /rmo-2021/ /rmo-2021 301
 
 # Personal Links
+/abbie-axel https://joshukraine.com/abbie-axel/ 302
 /wish-list https://joshukraine.notion.site/Joshua-s-Wish-List-2f2e7b831c1f46e4962a5c8ed3842c04 301
 /fb https://www.facebook.com/joshukraine 301
 /x https://x.com/joshukraine 301

--- a/links/index.html
+++ b/links/index.html
@@ -158,6 +158,14 @@
     <div class="links-grid">
         <div class="link-card">
     <div class="link-info">
+        <a href="https://jsua.co/abbie-axel" class="link-url" target="_blank">jsua.co/abbie-axel</a>
+        <div class="link-desc" title="Abbie &amp; Axel wedding info (temporary placeholder)">Abbie &amp; Axel wedding info (temporary placeholder)</div>
+    </div>
+    <button class="copy-btn" onclick="copyToClipboard('https://jsua.co/abbie-axel', this)">Copy</button>
+</div>
+
+<div class="link-card">
+    <div class="link-info">
         <a href="https://jsua.co/wish-list" class="link-url" target="_blank">jsua.co/wish-list</a>
         <div class="link-desc" title="Personal wish list">Personal wish list</div>
     </div>
@@ -299,9 +307,9 @@
 
         
         <div class="stats">
-            <p><strong>Total Short URLs:</strong> 16</p>
+            <p><strong>Total Short URLs:</strong> 17</p>
             <p><strong>Root redirect:</strong> Yes</p>
-<p><strong>Personal:</strong> 5 links</p>
+<p><strong>Personal:</strong> 6 links</p>
 <p><strong>Developer:</strong> 5 links</p>
 <p><strong>Ministry:</strong> 4 links</p>
 <p><strong>Third Party:</strong> 1 links</p>

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -11,6 +11,11 @@ root:
 # Format: path (without leading slash), destination URL, optional status code (defaults to 301), description
 redirects:
   personal:
+    - path: abbie-axel
+      url: https://joshukraine.com/abbie-axel/
+      status: 302
+      description: Abbie & Axel wedding info (temporary placeholder)
+
     - path: wish-list
       url: https://joshukraine.notion.site/Joshua-s-Wish-List-2f2e7b831c1f46e4962a5c8ed3842c04
       description: Personal wish list


### PR DESCRIPTION
## Summary
- Add `jsua.co/abbie-axel` pointing at the temporary placeholder page at `https://joshukraine.com/abbie-axel/`
- Uses **302 (temporary)** so browsers and caches don't pin the destination — when the permanent TheKnot.com page is ready, we just flip the `url:` in `redirects.yaml` and every existing QR code follows automatically

## Context
This redirect is going on a print newsletter going out in the next ~48 hours. The print QR code encodes `jsua.co/abbie-axel`, which gives us a stable layer of indirection over the destination as it changes (placeholder → TheKnot.com → potentially elsewhere).

## Test plan
- [x] Destination URL returns HTTP 200 (`curl -I https://joshukraine.com/abbie-axel/`)
- [x] `bundle exec rake test` — 10/10 pass
- [x] `ruby generate_redirects.rb` — generates `/abbie-axel https://joshukraine.com/abbie-axel/ 302`
- [ ] CI green
- [ ] After merge: `curl -I https://jsua.co/abbie-axel` returns 302 → `joshukraine.com/abbie-axel/`