### PR TITLE
chore: default redirect status to 302 instead of 301

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,11 @@ URL redirect management for the `jsua.co` domain, served by Cloudflare Pages. A 
 ```yaml
 - path: example                 # required, no leading slash
   url: https://example.com      # required, prefer HTTPS
-  status: 301                   # optional, defaults to 301 (use 302 for temporary)
+  status: 302                   # optional, defaults to 302 (use 301 only for truly permanent destinations)
   description: Example redirect # optional, shown on /links page
 ```
+
+**Why 302 by default:** This repo is a redirect-management service whose purpose is to provide a stable short URL over a destination that may evolve. A 302 response tells clients/caches not to pin the redirect, so when we change `url:` later (e.g., flipping a placeholder to a permanent site), every existing QR code or printed link starts following the new destination on the next request. Use `status: 301` only when you're confident the destination will never need to move.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Visit [jsua.co/links](https://jsua.co/links) to see all available short URLs wit
 1. The `_redirects` file contains simple mappings in the format:
 
    ```text
-   /short-path https://full-destination-url.com 301
+   /short-path https://full-destination-url.com 302
    ```
 
 2. Cloudflare Pages automatically deploys changes when this repo is updated
@@ -37,8 +37,8 @@ To add a new redirect:
 
 1. Edit the `redirects.yaml` file
 2. Add your redirect under the appropriate section
-3. Run `ruby generate_redirects.rb` to regenerate the `_redirects` file
-4. Commit both files and push to GitHub
+3. Run `ruby generate_redirects.rb` to regenerate the `_redirects` file and the `/links` landing page
+4. Commit all three files (`redirects.yaml`, `_redirects`, `links/index.html`) and push to GitHub
 5. Cloudflare Pages will auto-deploy the changes
 
 Example YAML entry:
@@ -48,12 +48,17 @@ redirects:
     - path: example
       url: https://example.com
       description: Example redirect
-  
+
   personal:
     - path: my-link
       url: https://mywebsite.com
+      status: 301              # optional; defaults to 302
       description: Personal website
 ```
+
+### A note on status codes
+
+The optional `status:` field defaults to `302` (temporary). Because this repo exists to provide a stable short URL over a destination that may evolve, `302` keeps browsers and caches from pinning the destination — so when you change a `url:` later, every existing QR code or printed link follows the new target on the next request. Use `status: 301` only for entries whose destination is genuinely permanent.
 
 ## Examples
 

--- a/_redirects
+++ b/_redirects
@@ -28,26 +28,26 @@
 
 # Personal Links
 /abbie-axel https://joshukraine.com/abbie-axel/ 302
-/wish-list https://joshukraine.notion.site/Joshua-s-Wish-List-2f2e7b831c1f46e4962a5c8ed3842c04 301
-/fb https://www.facebook.com/joshukraine 301
-/x https://x.com/joshukraine 301
-/strava https://www.strava.com/athletes/joshukraine 301
-/pay https://www.paypal.com/paypalme/joshukraine 301
+/wish-list https://joshukraine.notion.site/Joshua-s-Wish-List-2f2e7b831c1f46e4962a5c8ed3842c04 302
+/fb https://www.facebook.com/joshukraine 302
+/x https://x.com/joshukraine 302
+/strava https://www.strava.com/athletes/joshukraine 302
+/pay https://www.paypal.com/paypalme/joshukraine 302
 
 # Developer Links
-/dotfiles https://github.com/joshukraine/dotfiles 301
-/github https://github.com/joshukraine 301
-/macos https://github.com/joshukraine/mac-bootstrap 301
-/mm-gulp https://github.com/joshukraine/middleman-gulp 301
-/laptop https://github.com/joshukraine/laptop 301
+/dotfiles https://github.com/joshukraine/dotfiles 302
+/github https://github.com/joshukraine 302
+/macos https://github.com/joshukraine/mac-bootstrap 302
+/mm-gulp https://github.com/joshukraine/middleman-gulp 302
+/laptop https://github.com/joshukraine/laptop 302
 
 # Ministry Links
-/nov-proj-2024 https://www.youtube.com/playlist?list=PLwBim7LWPkXVHyH1OtgqtTQU0SyhVNBzn 301
-/pioneers-info https://www.notion.so/joshukraine/Pioneers-Info-Center-d19fd3f2c39947e1baa757968fb73184 301
-/pioneers-zoom-part-1 https://youtu.be/Fo19lxOQJp8 301
-/verses https://gist.github.com/joshukraine/4fbeb76580ef113a2c1f13b7c1c8b123 301
+/nov-proj-2024 https://www.youtube.com/playlist?list=PLwBim7LWPkXVHyH1OtgqtTQU0SyhVNBzn 302
+/pioneers-info https://www.notion.so/joshukraine/Pioneers-Info-Center-d19fd3f2c39947e1baa757968fb73184 302
+/pioneers-zoom-part-1 https://youtu.be/Fo19lxOQJp8 302
+/verses https://gist.github.com/joshukraine/4fbeb76580ef113a2c1f13b7c1c8b123 302
 
 # Third Party Links
-/rmo-2021 https://goodandevilbook.com/english/ 301
+/rmo-2021 https://goodandevilbook.com/english/ 302
 
 # vim: set filetype=apache:

--- a/lib/redirect_generator.rb
+++ b/lib/redirect_generator.rb
@@ -61,7 +61,7 @@ class RedirectGenerator
 
   def write_root_redirect(file, root)
     file.puts "# Root domain redirect"
-    status = root["status"] || 301
+    status = root["status"] || 302
     file.puts "/ #{root["url"]} #{status}"
     file.puts
   end
@@ -107,7 +107,7 @@ class RedirectGenerator
     category_redirects.each do |redirect|
       path = redirect["path"]
       url = redirect["url"]
-      status = redirect["status"] || 301
+      status = redirect["status"] || 302
       file.puts "/#{path} #{url} #{status}"
     end
     file.puts

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -8,7 +8,12 @@ root:
   status: 301
 
 # Redirect definitions organized by category
-# Format: path (without leading slash), destination URL, optional status code (defaults to 301), description
+# Format: path (without leading slash), destination URL, optional status code (defaults to 302), description
+#
+# Note on status: this is a redirect-management service whose purpose is to provide a stable
+# short URL while the destination may evolve over time. The default is 302 (temporary) so
+# clients/caches don't pin a destination we may want to change later. Use status: 301 only
+# for entries whose destination is genuinely permanent.
 redirects:
   personal:
     - path: abbie-axel

--- a/test/test_redirect_generator.rb
+++ b/test/test_redirect_generator.rb
@@ -103,7 +103,7 @@ class TestRedirectGenerator < Minitest::Test
     assert_includes content, "/test https://test.com 301"
   end
 
-  def test_defaults_to_301_status
+  def test_defaults_to_302_status
     config = {
       "redirects" => {
         "personal" => [
@@ -126,7 +126,33 @@ class TestRedirectGenerator < Minitest::Test
     generator.generate
 
     content = File.read(@output_file)
-    assert_includes content, "/test https://test.com 301"
+    assert_includes content, "/test https://test.com 302"
+  end
+
+  def test_explicit_301_status_overrides_default
+    config = {
+      "redirects" => {
+        "personal" => [
+          {
+            "path" => "permanent",
+            "url" => "https://permanent.example",
+            "status" => 301
+          }
+        ]
+      }
+    }
+    write_yaml(@config_file, config)
+
+    generator = RedirectGenerator.new(
+      config_file: @config_file,
+      output_file: @output_file,
+      html_output_file: @html_output_file
+    )
+
+    generator.generate
+
+    content = File.read(@output_file)
+    assert_includes content, "/permanent https://permanent.example 301"
   end
 
   def test_categorizes_redirects_correctly
@@ -181,10 +207,10 @@ class TestRedirectGenerator < Minitest::Test
     assert ministry_pos < third_party_pos
 
     # Check redirects are under correct categories
-    assert_match(/# Personal Links.*\/personal1 https:\/\/personal1.com 301/m, content)
-    assert_match(/# Developer Links.*\/dev1 https:\/\/dev1.com 301/m, content)
-    assert_match(/# Ministry Links.*\/ministry1 https:\/\/ministry1.com 301/m, content)
-    assert_match(/# Third Party Links.*\/third1 https:\/\/third1.com 301/m, content)
+    assert_match(/# Personal Links.*\/personal1 https:\/\/personal1.com 302/m, content)
+    assert_match(/# Developer Links.*\/dev1 https:\/\/dev1.com 302/m, content)
+    assert_match(/# Ministry Links.*\/ministry1 https:\/\/ministry1.com 302/m, content)
+    assert_match(/# Third Party Links.*\/third1 https:\/\/third1.com 302/m, content)
   end
 
   def test_defaults_to_personal_category
@@ -209,7 +235,7 @@ class TestRedirectGenerator < Minitest::Test
     generator.generate
 
     content = File.read(@output_file)
-    assert_match(/# Personal Links.*\/test https:\/\/test.com 301/m, content)
+    assert_match(/# Personal Links.*\/test https:\/\/test.com 302/m, content)
   end
 
   def test_handles_empty_categories


### PR DESCRIPTION
## Summary
- Flip the generator's fallback status code from `301` (permanent) to `302` (temporary), aligning the default with what this repo is actually for: a stable indirection layer over destinations that may change
- Explicit `status: 301` in YAML continues to work as an opt-in for genuinely permanent destinations
- Trailing-slash canonicalization redirects (e.g. `/foo/` → `/foo`) remain `301` because that's a true permanent path normalization, not a destination choice
- All 15 entries that previously inherited the `301` default now emit `302` in the regenerated `_redirects`

## Rationale
jsua.co is a redirect-management service. Its entire purpose is to keep a short URL stable while the destination may evolve. A `301` baked into client/cache state works against that purpose — once delivered, it's hard to recall. `302` keeps every scan re-checking Cloudflare, so when we change a `url:` in `redirects.yaml` later (the wedding placeholder → TheKnot, a renamed GitHub repo, a moved Notion page, etc.), every existing QR code and printed link follows on the next request. The marginal performance cost (one extra edge round-trip per scan, ~30-80ms) is invisible at this scale.

## Note on the root redirect
The root entry (`/` → `ofreport.com`) still has an explicit `status: 301` in `redirects.yaml` from before this change, and is therefore still emitted as `301`. Whether to remove that explicit status and let the root inherit the new 302 default is left for a separate decision.

## Test plan
- [x] `bundle exec rake test` — 11/11 pass, including new `test_explicit_301_status_overrides_default` regression test
- [x] `bundle exec standardrb` — clean
- [x] `ruby generate_redirects.rb` — generates without drift
- [x] Manual diff review of `_redirects`: 15 destination entries flipped 301 → 302; trailing-slash redirects unchanged at 301; root unchanged at explicit 301
- [x] CI green
- [ ] After merge: `curl -I https://jsua.co/dotfiles` returns `302` (will be different from before — expected)